### PR TITLE
prevent repeating dashes in slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target/
 boot/
+
+.bloop
+.bsp
+.metals
+.vscode

--- a/lila/src/main/scala/StringOps.scala
+++ b/lila/src/main/scala/StringOps.scala
@@ -18,7 +18,7 @@ object StringOps:
       val normalized = Normalizer.normalize(noWhitespace, Normalizer.Form.NFD)
       val noSpecial = slugR.replaceAllIn(normalized, "")
       val slug = slugMultiDashRegex.replaceAllIn(noSpecial, "-")
-      slug.stripPrefix("-").stripSuffix("-")
+      slug.stripPrefix("-").stripSuffix("-").toLowerCase
 
   private val onelineR = """\s+""".r
   def shorten(text: String, length: Int): String = shorten(text, length, "…")

--- a/lila/src/main/scala/StringOps.scala
+++ b/lila/src/main/scala/StringOps.scala
@@ -8,13 +8,17 @@ object StringOps:
   object slug:
     private val slugR = """[^\w-]""".r
     private val slugMultiDashRegex = """-{2,}""".r
+    private val mdash = '—'
+    private val ndash = '–'
+    private val specialDashChars = s"[$mdash$ndash]".r
 
     def apply(input: String) =
-      val nowhitespace = input.trim.replace(' ', '-')
-      val singleDashes = slugMultiDashRegex.replaceAllIn(nowhitespace, "-")
-      val normalized = Normalizer.normalize(singleDashes, Normalizer.Form.NFD)
-      val slug = slugR.replaceAllIn(normalized, "")
-      slug.toLowerCase
+      val noSpecialDashes = specialDashChars.replaceAllIn(input.trim, "-")
+      val noWhitespace = noSpecialDashes.replace(' ', '-')
+      val normalized = Normalizer.normalize(noWhitespace, Normalizer.Form.NFD)
+      val noSpecial = slugR.replaceAllIn(normalized, "")
+      val slug = slugMultiDashRegex.replaceAllIn(noSpecial, "-")
+      slug.toLowerCase.dropWhile(_ == '-').reverse.dropWhile(_ == '-').reverse
 
   private val onelineR = """\s+""".r
   def shorten(text: String, length: Int): String = shorten(text, length, "…")

--- a/lila/src/main/scala/StringOps.scala
+++ b/lila/src/main/scala/StringOps.scala
@@ -18,7 +18,7 @@ object StringOps:
       val normalized = Normalizer.normalize(noWhitespace, Normalizer.Form.NFD)
       val noSpecial = slugR.replaceAllIn(normalized, "")
       val slug = slugMultiDashRegex.replaceAllIn(noSpecial, "-")
-      slug.toLowerCase.dropWhile(_ == '-').reverse.dropWhile(_ == '-').reverse
+      slug.stripPrefix("-").stripSuffix("-")
 
   private val onelineR = """\s+""".r
   def shorten(text: String, length: Int): String = shorten(text, length, "…")

--- a/lila/src/test/scala/StringOpsTest.scala
+++ b/lila/src/test/scala/StringOpsTest.scala
@@ -8,6 +8,31 @@ class StringTest extends munit.FunSuite:
     assert(!slug("hello \" world").contains("\""))
     assert(!slug("<<<").contains("<"))
 
+  test("slugs"):
+    val expected = "hello-world"
+    assertEquals(slug("hello world"), expected)
+    assertEquals(slug("  hello world  "), expected)
+    assertEquals(slug("hello   world"), expected)
+    assertEquals(slug("hello | world"), expected)
+    assertEquals(slug("hello - - - world"), expected)
+    assertEquals(slug("héllö wörld"), expected)
+    assertEquals(slug("héllö   wörld"), expected)
+    assertEquals(slug("héllö   wörld!"), expected)
+    assertEquals(slug("héllö   wörld!  "), expected)
+    assertEquals(slug("héllö   wörld!  !!!"), expected)
+    assertEquals(slug("héllö   wörld!  !!!   "), expected)
+
+  test("slugs with mdash and ndash"):
+    val mdash = '—'
+    val ndash = '–'
+    val expected = "hello-world"
+    assertEquals(slug(s"hello ${mdash} world"), expected)
+    assertEquals(slug(s"hello ${ndash} world"), expected)
+    assertEquals(slug(s"hello${mdash}world"), expected)
+    assertEquals(slug(s"hello${ndash}world"), expected)
+    assertEquals(slug(s"hello ${mdash} - ${ndash} world"), expected)
+    assertEquals(slug(s"hello ${mdash} - ${ndash} | world"), expected)
+
   val i18nValidStrings = List(
     """éâòöÌÒÒçÇ""",
     """صارف اپنا نام تبدیل کریں۔ یہ صرف ایک دفعہ ہو سکتا ہے اور صرف انگریزی حروف چھوٹے یا بڑے کرنے کی اجازت ہے۔.""",

--- a/lila/src/test/scala/StringOpsTest.scala
+++ b/lila/src/test/scala/StringOpsTest.scala
@@ -21,6 +21,7 @@ class StringTest extends munit.FunSuite:
     assertEquals(slug("héllö   wörld!  "), expected)
     assertEquals(slug("héllö   wörld!  !!!"), expected)
     assertEquals(slug("héllö   wörld!  !!!   "), expected)
+    assertEquals(slug("HeLlO WoRlD"), expected)
 
   test("slugs with mdash and ndash"):
     val mdash = '—'


### PR DESCRIPTION
Example URL with repeating dashes: [/broadcast/3rd-uzchess-cup-2026--masters/round-1/HMXdFRwx](https://lichess.org/broadcast/3rd-uzchess-cup-2026--masters/round-1/HMXdFRwx)

```
https://lichess.org/broadcast/3rd-uzchess-cup-2026--masters/round-1/HMXdFRwx
                                                  ^^  
                                                  2 dashes  
```

because the real name is: `3rd UzChess Cup 2026 | Masters`